### PR TITLE
Fix post rendering with kustomize

### DIFF
--- a/charts/heimdall/templates/heimdall/statefulset.yaml
+++ b/charts/heimdall/templates/heimdall/statefulset.yaml
@@ -183,7 +183,7 @@ spec:
           command: # TODO chain ID should be based on network selection
             - sh
             - -c
-            - |-
+            - |
               set -x;
 
               export HEIMDALL_DIR=/storage;

--- a/charts/heimdall/templates/heimdall/statefulset.yaml
+++ b/charts/heimdall/templates/heimdall/statefulset.yaml
@@ -183,7 +183,7 @@ spec:
           command: # TODO chain ID should be based on network selection
             - sh
             - -c
-            - >-
+            - |-
               set -x;
 
               export HEIMDALL_DIR=/storage;


### PR DESCRIPTION
Issue is akin to this one: https://issuehint.com/issue/fluxcd/flux2/1968

As is, when using in Flux, in which the controller uses kustomize as a post renderer, results in an extra empty line in the command line which breaks the deployment.